### PR TITLE
cicd: Tweak ghr config for GitHub releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,25 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-<!--
-Any notes about merges to master that haven't been added to a Git tag should go
-here. When it's time to cut a new release, create a header for the new version
-below and move the content of this section down to the new version.
-
-### Added
-
-If you add any new code or functionality, document your changes here.
-
-### Changed
-
-If you change any existing code or functionality, document your changes here.
-
-### Removed
-
-If you remove any existing code or functionality, document your changes here.
-
--->
-
 Upcoming release
 
 ### Added
@@ -35,11 +16,14 @@ Upcoming release
 - `make debug`: Display generated vars used in the Makefile
 - Commit vendored modules to the repo
 - `.go-version` file set to 1.14.0
+- Include sha256 checksum file for binaries
+- `make release-draft`: Publish a draft release to GitHub
 
 ### Changed
 
 - `make build_all`: Use `go mod tidy` and `go mod vendor`
 - Determine version from Git describe output
+- Built binaries now include the version string
 
 ### Removed
 

--- a/Makefile
+++ b/Makefile
@@ -22,17 +22,25 @@ build: ## Build binary for the current platform
 	@echo "Building binary for your current environment"
 	go build ${LDFLAGS}
 
-build_all: ## Build multi-platform binaries
+build-all: ## Build multi-platform binaries
 	@echo "Tidying and vendoring go modules"
 	go mod tidy
 	go mod vendor
 	@echo "Building multi-platform binaries using gox"
-	gox ${LDFLAGS} -output "dist/${BIN_NAME}_{{.OS}}_{{.Arch}}"
+	gox ${LDFLAGS} -output "dist/${BIN_NAME}-${VERSION}-{{.OS}}-{{.Arch}}"
 
-release: ## Publish release binaries to GitHub
+release: gen-checksums ## Publish release binaries to GitHub
 	@echo "Publishing release binaries to GitHub"
 	@if [ "$$(git diff --stat)" ]; then echo "Git tree is dirty! Aborting"; exit 1; fi
-	ghr -t $$GITHUB_TOKEN -u ${GH_OWNER} -r ${GH_REPO} --replace `git describe --tags` dist/
+	ghr -soft ${VERSION} dist/
+
+release-draft: gen-checksums ## Publish draft release binaries to GitHub
+	@echo "Publishing draft release binaries to GitHub"
+	ghr -replace -draft -name ${VERSION} ${VERSION} dist/
+
+gen-checksums: ## Generate sha256 checksum file
+	@echo "Generating sha256 sums for binaries"
+	sha256sum dist/* > dist/${BIN_NAME}-${VERSION}.sha256sums
 
 tools: ## Install build and release tools
 	@echo "Installing build and release tools"


### PR DESCRIPTION
Get the ghr config working locally. Related to #5.

Added:

- Include sha256 checksum file for binaries
- `make release-draft`: Publish a draft release to GitHub

Changed:

- Built binaries now include the version string
